### PR TITLE
Update to formatting errata for p. 108 - code should be bold.

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -166,6 +166,19 @@ The section on `--fair algorithm` should note that making an algorithm globally 
 
 ---
 
+On **page 108** [Formatting]:
+
+The following code should be in bold:
+
+```
+EXTENDS TLC, Integers, Sequences
+\* CONSTANT Threads
+
+Threads == 1..2
+```
+
+---
+
 On **page 114** [Text Change]:
 
 The text should read "~~TLC~~ **The Pluscal Translator** will create a constant `DefaultInitValue`..."


### PR DESCRIPTION
While working through the book, I ran into errors on the Dekker Algorithm example in Chapter 6. I checked the errata and there was nothing relevant. After staring at the page for a few minutes, I noticed a section of the code at the top which had been updated, but was not formatted in bold. 

This adds the relevant code section to the errata.